### PR TITLE
Update board_item.dart

### DIFF
--- a/lib/board_item.dart
+++ b/lib/board_item.dart
@@ -89,7 +89,7 @@ class BoardItemState extends State<BoardItem> with AutomaticKeepAliveClientMixin
 
   @override
   Widget build(BuildContext context) {
-    WidgetsBinding.instance!
+    WidgetsBinding.instance
         .addPostFrameCallback((_) => afterFirstLayout(context));
     if (widget.boardList!.itemStates.length > widget.index!) {
       widget.boardList!.itemStates.removeAt(widget.index!);


### PR DESCRIPTION
fixed warning from flutter 3.
Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.