### PR TITLE
Update boardview.dart

### DIFF
--- a/lib/boardview.dart
+++ b/lib/boardview.dart
@@ -566,7 +566,7 @@ class BoardViewState extends State<BoardView> with AutomaticKeepAliveClientMixin
       if (widget.middleWidget != null) {
         stackWidgets.add(Container(key:_middleWidgetKey,child:widget.middleWidget));
       }
-      WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
         if(mounted){
           setState(() {});
         }


### PR DESCRIPTION
fixed warning from flutter 3.
Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.